### PR TITLE
Update cnn_architecture.py

### DIFF
--- a/ASCAD/N0=0/cnn_architecture.py
+++ b/ASCAD/N0=0/cnn_architecture.py
@@ -92,7 +92,7 @@ def train_model(X_profiling, Y_profiling, X_test, Y_test, model, save_file_name,
     save_model = ModelCheckpoint(save_file_name)
 
     # Get the input layer shape
-    input_layer_shape = model.get_layer(index=0).input_shape
+    input_layer_shape = model.get_layer(index=0).input_shape[0]
 
     # Sanity check
     if input_layer_shape[1] != len(X_profiling[0]):


### PR DESCRIPTION
Input_shape is [(None,700,1)]. We should rather use input_shape[0], because before doing this modification, the line "if input_layer_shape[1] != len(X_profiling[0]):" showed me an index out of range error 